### PR TITLE
fix: make auth routes public

### DIFF
--- a/my_memo_master_front/src/router/routes.js
+++ b/my_memo_master_front/src/router/routes.js
@@ -59,7 +59,6 @@ const routes = [
     component: () => import('../pages/register/InscriptionPage.vue'),
     meta: {
       title: 'register',
-      private: true,
     },
   },
   {
@@ -68,7 +67,6 @@ const routes = [
     component: () => import('../pages/login/ConnexionPage.vue'),
     meta: {
       title: 'login',
-      private: true,
     },
   },
   {


### PR DESCRIPTION
## Summary
- allow access to authentication pages without login

## Testing
- `npm test`
- `npm run lint` *(fails: Component name "Interpreter" should always be multi-word, 'formula' is not defined, Unnecessary escape character, 'reverseMapping' is assigned a value but never used, Unexpected combined character in character class, 'index' is defined but never used, 'Button' is defined but never used, 'Dropdown' is defined but never used, 'addToInput' is assigned a value but never used, 'interpretedContent' is assigned a value but never used, 'handleDelete' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d21309d883318c30fabe6ae2f814