### PR TITLE
Fix env file path for docker compose

### DIFF
--- a/server_docker_compose/preprod/docker-compose.yml
+++ b/server_docker_compose/preprod/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   api:
     image: ${IMAGE_API}
     env_file:
-      - .env
+      - ../../.env
     volumes:
       - api-data:/app/data
     environment:
@@ -67,7 +67,7 @@ services:
       - postgres
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mmm-preprod-api.rule=Host(`api.tests.my-memo-master.com`)
+      - traefik.http.routers.mmm-preprod-api.rule=Host(`${API_DOMAIN}`)
       - traefik.http.routers.mmm-preprod-api.entrypoints=websecure
       - traefik.http.routers.mmm-preprod-api.tls.certresolver=letsencrypt
       - traefik.http.services.mmm-preprod-api.loadbalancer.server.port=${API_PORT}
@@ -83,7 +83,7 @@ services:
     depends_on:
       - api
     env_file:
-      - .env
+      - ../../.env
     environment:
       - APP_PUBLIC_URL=https://${FRONT_DOMAIN}
       - APP_API_URL=https://${API_DOMAIN}

--- a/server_docker_compose/prod/docker-compose.yml
+++ b/server_docker_compose/prod/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   postgres:
     image: postgres:16
     env_file:
-      - .env
+      - ../../.env
     environment:
       POSTGRES_USER: ${PG_USER}
       POSTGRES_PASSWORD: ${PG_PASS}
@@ -19,7 +19,7 @@ services:
   pgadmin:
     image: dpage/pgadmin4
     env_file:
-      - .env
+      - ../../.env
     volumes:
       - pgadmin-data:/var/lib/pgadmin
     depends_on: [postgres]
@@ -38,7 +38,7 @@ services:
   api:
     image: fredissimo/mymemomaster_api:latest
     env_file:
-      - .env
+      - ../../.env
     volumes:
       - api-data:/app/data
     environment:
@@ -76,7 +76,7 @@ services:
   front:
     image: fredissimo/mymemomaster_front:latest
     env_file:
-      - .env
+      - ../../.env
     environment:
       # Vite/frontend runtime variables (used at build time)
       VITE_APP_NAME: ${VITE_APP_NAME}


### PR DESCRIPTION
## Summary
- ensure docker compose services load shared .env file
- configure preprod API router to use API_DOMAIN variable

## Testing
- `npm test` (my_memo_master_api)
- `npm test` (my_memo_master_front)


------
https://chatgpt.com/codex/tasks/task_e_68c29f39431883318ee905e6e2518b4d