### PR TITLE
Fix env file path for docker compose

### DIFF
--- a/server_docker_compose/preprod/docker-compose.yml
+++ b/server_docker_compose/preprod/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - postgres
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mmm-preprod-api.rule=Host(`api.tests.my-memo-master.com`)
+      - traefik.http.routers.mmm-preprod-api.rule=Host(`${API_DOMAIN}`)
       - traefik.http.routers.mmm-preprod-api.entrypoints=websecure
       - traefik.http.routers.mmm-preprod-api.tls.certresolver=letsencrypt
       - traefik.http.services.mmm-preprod-api.loadbalancer.server.port=${API_PORT}


### PR DESCRIPTION
## Summary
- ignore environment files instead of using symlinks
- load per-directory `.env` in preprod and prod compose files

## Testing
- `npm test` (my_memo_master_api)
- `npm test -- --run` (my_memo_master_front)


------
https://chatgpt.com/codex/tasks/task_e_68c29f39431883318ee905e6e2518b4d