### PR TITLE
Fix Role table name mismatch causing sync failure

### DIFF
--- a/my_memo_master_api/models/Role.model.js
+++ b/my_memo_master_api/models/Role.model.js
@@ -1,31 +1,35 @@
-const { DataTypes } = require('sequelize');
+const { DataTypes } = require("sequelize");
 
 module.exports = (instance) => {
-    return instance.define('Role', {
-        roleId: {
-            type: DataTypes.INTEGER,
-            autoIncrement: true,
-            allowNull: false,
-            primaryKey: true,
-        },
-        name: {
-            type: DataTypes.STRING(50),
-            allowNull: false,
-        },
-        updatedAt: {
-            type: DataTypes.DATE,
-            allowNull: false,
-            defaultValue: DataTypes.NOW,
-        },
-        createdAt: {
-            type: DataTypes.DATE,
-            allowNull: false,
-            defaultValue: DataTypes.NOW,
-        },
-    }, {
-        tableName: 'roles',
-        updatedAt: 'updatedAt',
-        createdAt: 'createdAt',
-        timestamps: true,
-    })
-}
+  return instance.define(
+    "Role",
+    {
+      roleId: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        allowNull: false,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING(50),
+        allowNull: false,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      tableName: "Role",
+      updatedAt: "updatedAt",
+      createdAt: "createdAt",
+      timestamps: true,
+    }
+  );
+};


### PR DESCRIPTION
## Summary
- align the Role model definition with the expected table name so Sequelize can create the table before syncing User
- tidy the model definition formatting for consistency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b02221b4833197ade63019282dfe